### PR TITLE
Fix copies and update localStorage variables

### DIFF
--- a/packages/ui/src/components/ContactCard.vue
+++ b/packages/ui/src/components/ContactCard.vue
@@ -15,9 +15,9 @@
       </p>
     </div>
     <div
+      v-if="!isEmptySocials"
       :id="`details-${contact?.timestamp}`"
       class="details"
-      v-if="!isEmptySocials"
     >
       <div class="content">
         <div v-for="social in socialDetails" :key="social.key">
@@ -96,13 +96,15 @@ export default {
       if (!showDetails.value) {
         gsap.to(`#details-${props.contact.timestamp}`, {
           duration: 0.2,
+          display: 'none',
           height: 0,
           ease: Sine.easeIn,
         })
       } else {
         gsap.to(`#details-${props.contact.timestamp}`, {
           duration: 0.2,
-          height: 104,
+          display: 'block',
+          height: 114,
           ease: Sine.easeIn,
         })
       }
@@ -134,19 +136,20 @@ export default {
 
 <style lang="scss" scoped>
 .contact-info {
-  max-width: 250px;
+  max-width: 600px;
   overflow: hidden;
-  text-overflow: ellipsis;
+  overflow-wrap: break-word;
 }
 .details {
   background: $dark-screen;
+  display: none;
   height: 0;
-  overflow: hidden;
   margin-bottom: 1px;
   .content {
     padding: 16px;
   }
   .social {
+    height: 30px;
     text-decoration: underline;
     cursor: pointer;
     display: grid;
@@ -155,6 +158,13 @@ export default {
     align-items: center;
     color: $screen;
     font-weight: bolder;
+    .contact-info {
+      height: 30px;
+      width: 600px;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
     .social-icon {
       width: 16px;
     }
@@ -183,6 +193,18 @@ export default {
   .date {
     width: max-content;
     font-size: 12px;
+  }
+}
+@media (max-width: 600px) {
+  .contact-info {
+    max-width: 250px;
+  }
+  .details {
+    .social {
+      .contact-info {
+        width: 300px;
+      }
+    }
   }
 }
 </style>

--- a/packages/ui/src/constants.js
+++ b/packages/ui/src/constants.js
@@ -229,8 +229,8 @@ export const TESTNET_NETWORKS = {
 }
 
 export const NETWORKS =
-  process.env.VITE_ALLOW_TEST_NETWORKS &&
-  Number(process.env.VITE_ALLOW_TEST_NETWORKS)
+  import.meta.env.VITE_ALLOW_TEST_NETWORKS &&
+  Number(import.meta.env.VITE_ALLOW_TEST_NETWORKS)
     ? { ...MAINNET_NETWORKS, ...TESTNET_NETWORKS }
     : MAINNET_NETWORKS
 

--- a/packages/ui/src/router/index.js
+++ b/packages/ui/src/router/index.js
@@ -107,12 +107,12 @@ const routes = [
         next('/')
       } else {
         localStorage.setItem(
-          'tokenInfo',
+          'wc3tokenInfo',
           JSON.stringify({ username, token, key })
         )
         if (txHash) {
           localStorage.setItem(
-            'mintInfo',
+            'wc3mintInfo',
             JSON.stringify({ txHash, mintConfirmation, from })
           )
         }

--- a/packages/ui/src/services/exportInformation.js
+++ b/packages/ui/src/services/exportInformation.js
@@ -1,8 +1,10 @@
 import { BASE_URL } from '../constants'
 
 export function createImportLink() {
-  const { key, username, token } = JSON.parse(localStorage.getItem('tokenInfo'))
-  const mintInfo = JSON.parse(localStorage.getItem('mintInfo'))
+  const { key, username, token } = JSON.parse(
+    localStorage.getItem('wc3tokenInfo')
+  )
+  const mintInfo = JSON.parse(localStorage.getItem('wc3mintInfo'))
   if (mintInfo?.mintConfirmation) {
     return `${BASE_URL}#/import?key=${key}&username=${username}&token=${token}&txHash=${mintInfo.txHash}&from=${mintInfo.from}&mintConfirmation=${mintInfo.mintConfirmation}`
   } else if (mintInfo?.txHash) {

--- a/packages/ui/src/stores/player.js
+++ b/packages/ui/src/stores/player.js
@@ -70,19 +70,19 @@ export const useStore = defineStore('player', {
     },
     saveClaimInfo(info) {
       localStorage.setItem(
-        'tokenInfo',
+        'wc3tokenInfo',
         JSON.stringify({ ...this.getToken(), ...info })
       )
     },
     // Color theme
     getTheme() {
-      const theme = localStorage.getItem('theme')
+      const theme = localStorage.getItem('wc3theme')
       if (theme) {
         this.theme = theme
       }
     },
     saveTheme(theme) {
-      localStorage.setItem('theme', theme)
+      localStorage.setItem('wc3theme', theme)
       this.theme = theme
     },
     // Socials
@@ -161,17 +161,17 @@ export const useStore = defineStore('player', {
     },
     // Mint info
     getMintInfo() {
-      const mintInfo = JSON.parse(localStorage.getItem('mintInfo'))
+      const mintInfo = JSON.parse(localStorage.getItem('wc3mintInfo'))
       if (mintInfo) {
         this.mintInfo = mintInfo
       }
     },
     saveMintInfo(info) {
-      localStorage.setItem('mintInfo', JSON.stringify({ ...info }))
+      localStorage.setItem('wc3mintInfo', JSON.stringify({ ...info }))
       this.mintInfo = info
     },
     clearMintInfo() {
-      localStorage.removeItem('mintInfo')
+      localStorage.removeItem('wc3mintInfo')
       this.mintInfo = null
     },
     clearMintBlockInfo() {
@@ -180,15 +180,15 @@ export const useStore = defineStore('player', {
         blockNumber: 0,
         blockHash: 0,
       }
-      localStorage.setItem('mintInfo', JSON.stringify(this.mintInfo))
+      localStorage.setItem('wc3mintInfo', JSON.stringify(this.mintInfo))
     },
     // Token Info
     getToken() {
-      return JSON.parse(localStorage.getItem('tokenInfo'))
+      return JSON.parse(localStorage.getItem('wc3tokenInfo'))
     },
     clearTokenInfo() {
-      localStorage.removeItem('tokenInfo')
-      localStorage.removeItem('theme')
+      localStorage.removeItem('wc3tokenInfo')
+      localStorage.removeItem('wc3theme')
     },
     // Errors
     clearError(error) {

--- a/packages/ui/src/views/ContactsList.vue
+++ b/packages/ui/src/views/ContactsList.vue
@@ -4,8 +4,7 @@
     <GameScreen :padding="false">
       <div v-if="!player.contacts.length" class="empty-state bold">
         <p class="state-text">
-          Once you get your egg incubated by other player, their contact info
-          will show up here if they allow it.
+          Users get a contact in the Contact List when they scan someone.
         </p>
         <p>
           What are you waiting for? Go looking for other players and ask them to

--- a/packages/ui/src/views/GameDisclaimer.vue
+++ b/packages/ui/src/views/GameDisclaimer.vue
@@ -4,7 +4,7 @@
     <GameScreen>
       <p class="long-text">
         <span class="bold">Remember:</span>
-        once you claim your egg, it will be forever linked to your web browser
+        once you claim your egg, it will be forever linked to this web browser
         and the QR code will not work in a different browser.
       </p>
       <p class="long-text">

--- a/packages/ui/src/views/UserSettings.vue
+++ b/packages/ui/src/views/UserSettings.vue
@@ -71,6 +71,11 @@
           label="share"
           @change="setValue"
         />
+        <p class="form-subtitle">
+          Your contact information will be shared with the player scanning your
+          egg. Disabling this option you will be asked before sharing your
+          information.
+        </p>
       </form>
       <router-link v-if="fromAuth" to="/">
         <CustomButton type="primary" :slim="true"> CONTINUE </CustomButton>
@@ -157,6 +162,10 @@ export default {
     font-size: 16px;
     text-align: left;
     font-weight: bold;
+  }
+  .form-subtitle {
+    font-size: 16px;
+    text-align: left;
   }
   .social-label {
     font-size: 16px;


### PR DESCRIPTION
- [x] Change the name of the variables stored in localstorage for the token to avoid collisions with past games.
- [x] Add a copy below share socials explaining what socials are, i.e: “Your contact information will be shared with the player scanning your egg. Disabling this option you will be asked before sharing your information“
- [x] Update empty contacts copy: users get a contact in the Contact List when they scan someone
- [x] Check Disclaimer on “Play now”: “…forever linked to this web browser…”, instead of “…your web browser…”